### PR TITLE
Add Dockerfile for using paper2html server in a container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:latest
+
+RUN apt-get update \
+    && apt-get install -y poppler-utils poppler-data \
+    && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* \
+    && git clone https://github.com/ktaaaki/paper2html.git \
+    && python -m pip --no-cache-dir install -e paper2html


### PR DESCRIPTION
Usage.

```
$ mkdir ~/paper2html/
$ cd ~/paper2html/
$ curl -O https://raw.githubusercontent.com/ktaaaki/paper2html/master/docker/Dockerfile
$ docker build . -t paper2html
$ docker run --rm -it -p 5000:5000 paper2html python paper2html/paper2html/main.py --host=0.0.0.0
```
