### PR TITLE
Minor fix Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,3 +5,7 @@ RUN apt-get update \
     && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* \
     && git clone https://github.com/ktaaaki/paper2html.git \
     && python -m pip --no-cache-dir install -e paper2html
+
+EXPOSE 5000
+
+CMD [ "python", "/paper2html/paper2html/main.py", "--host=0.0.0.0" ]


### PR DESCRIPTION
Add `CMD` to the Dockerfile.
The server will start automatically without your specific command.

```
$ mkdir ~/paper2html/
$ cd ~/paper2html/
$ curl -O https://raw.githubusercontent.com/ktaaaki/paper2html/master/docker/Dockerfile
$ docker build . -t paper2html
$ docker run --rm -it -p 5000:5000 paper2html
```