### PR TITLE
Fix Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ python3とgitをインストールした後，
 ## 基本的な使用方法
 まずブックマークレットを作成します．ブラウザで何かしらのページをお気に入り登録し，登録内容を編集してURLの欄の記述を以下のコードに書き換えます．
 ```
-javascript:var esc=encodeURIComponent;var d=document;var subw=window.open('http://localhost:5000/paper2html/convert/?url='+esc(location.href)).document;
+javascript:var esc=encodeURIComponent;var d=document;var subw=window.open('http://localhost:5000/paper2html/convert?url='+esc(location.href)).document;
 ```
 以下のコマンドで，ローカルでpaper2htmlサーバを立ち上げます．
 ```shell

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,4 +25,4 @@ RUN apk add --no-cache \
 
 EXPOSE 5000
 
-CMD [ "python3", "/paper2html/paper2html/main.py", "--host=0.0.0.0" ]
+CMD [ "python3", "/paper2html/paper2html/main.py", "--host=0.0.0.0", "--watch=True" ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,28 +1,14 @@
-FROM alpine
+FROM python:slim
 
 LABEL org.opencontainers.image.source=https://github.com/ktaaaki/paper2html
 
 COPY . /paper2html/
 
-RUN apk add --no-cache \
-        python3-dev \
-        py-pip \
-        poppler-utils \
-        poppler-data \
-        # Cryptography depenencies
-        # https://cryptography.io/en/latest/installation.html#alpine
-        gcc \
-        musl-dev \
-        libffi-dev \
-        openssl-dev \
-        cargo \
-        # Pillow depenencies
-        # https://pillow.readthedocs.io/en/latest/installation.html#external-libraries
-        # https://github.com/python-pillow/docker-images/blob/master/alpine/Dockerfile
-        zlib-dev \
-        jpeg-dev \
+RUN apt-get update \
+    && apt-get install -y poppler-utils poppler-data \
+    && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* \
     && python3 -m pip --no-cache-dir install -e paper2html
 
 EXPOSE 5000
 
-CMD [ "python3", "/paper2html/paper2html/main.py", "--host=0.0.0.0", "--watch=True" ]
+CMD [ "python", "/paper2html/paper2html/main.py", "--host=0.0.0.0", "--watch=True" ]


### PR DESCRIPTION
- Change base image from `alpine` to `python:slim` for reducing image size.
- Add `--watch` option to `CMD`.
- Fix the bookmarklet typo.