### PR TITLE
Add scripts for non-root user

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,13 +2,19 @@ FROM python:slim
 
 LABEL org.opencontainers.image.source=https://github.com/ktaaaki/paper2html
 
-COPY . /paper2html/
-
 RUN apt-get update \
-    && apt-get install -y poppler-utils poppler-data \
-    && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* \
-    && python3 -m pip --no-cache-dir install -e paper2html
+    && apt-get install -y --no-install-recommends \
+        poppler-utils \
+        poppler-data \
+    && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+
+COPY . /tmp/paper2html/
+WORKDIR /tmp
+RUN python -m pip --no-cache-dir install -e paper2html \
+    && chmod +x ./paper2html/docker/entrypoint.sh ./paper2html/docker/start.sh
 
 EXPOSE 5000
 
-CMD [ "python", "/paper2html/paper2html/main.py", "--host=0.0.0.0", "--watch=True" ]
+ENTRYPOINT [ "./paper2html/docker/entrypoint.sh" ]
+
+CMD [ "./paper2html/docker/start.sh" ]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+MOUNT_PATH=./paper_cache
+USER_NAME=paperuser
+
+# Check the permissions of the bind mount.
+if [[ -d "${MOUNT_PATH}" ]]; then
+    USER_UID=$(stat ${MOUNT_PATH} -c "%u")
+    USER_GID=$(stat ${MOUNT_PATH} -c "%g")
+    # Make sure that the USER is root or non-root user.
+    if [[ "${USER_UID}" != "0" ]]; then
+        # Creat the new user.
+        if [[ -z "$(getent passwd "${USER_NAME}")" ]]; then
+            groupadd -g ${USER_GID} ${USER_NAME}
+            useradd -m -s /bin/bash -u ${USER_UID} -g ${USER_NAME} ${USER_NAME}
+        fi
+        export USER_NAME
+    else
+        export USER_NAME=
+    fi
+else
+    export USER_NAME=
+fi
+
+exec "$@"

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+su ${USER_NAME} -c "python ./paper2html/paper2html/main.py --host=0.0.0.0 --watch=True"


### PR DESCRIPTION
Partial solve #19

Set up non-root user in the container automatically.

Usage with a bind mount.

```bash
docker run --rm -it -p 5000:5000 -v ${PWD}:/tmp/paper_cache ghcr.io/ktaaaki/paper2html
```

Thanks to the improvements in #24, copying a local PDF file to the bound directory will automatically generate an html file.

Note: Local file converting only works on Linux (include WSL2).